### PR TITLE
cleanup; issue fix in OutputLines(); a couple of utility constructor functions

### DIFF
--- a/logstreamer.go
+++ b/logstreamer.go
@@ -93,14 +93,18 @@ func (l *Logstreamer) Flush() error {
 func (l *Logstreamer) OutputLines() error {
 	for {
 		line, err := l.buf.ReadString('\n')
+
+		if len(line) > 0 {
+			l.out(line)
+		}
+
 		if err == io.EOF {
 			break
 		}
+
 		if err != nil {
 			return err
 		}
-
-		l.out(line)
 	}
 
 	return nil

--- a/logstreamer.go
+++ b/logstreamer.go
@@ -57,7 +57,9 @@ func (l *Logstreamer) Write(p []byte) (n int, err error) {
 }
 
 func (l *Logstreamer) Close() error {
-	l.Flush()
+	if err := l.Flush(); err != nil {
+		return err
+	}
 	l.buf = bytes.NewBuffer([]byte(""))
 	return nil
 }
@@ -72,7 +74,7 @@ func (l *Logstreamer) Flush() error {
 	return nil
 }
 
-func (l *Logstreamer) OutputLines() (err error) {
+func (l *Logstreamer) OutputLines() error {
 	for {
 		line, err := l.buf.ReadString('\n')
 		if err == io.EOF {
@@ -94,7 +96,7 @@ func (l *Logstreamer) FlushRecord() string {
 	return buffer
 }
 
-func (l *Logstreamer) out(str string) (err error) {
+func (l *Logstreamer) out(str string) {
 	if l.record == true {
 		l.persist = l.persist + str
 	}
@@ -108,6 +110,4 @@ func (l *Logstreamer) out(str string) (err error) {
 	}
 
 	l.Logger.Print(str)
-
-	return nil
 }

--- a/logstreamer.go
+++ b/logstreamer.go
@@ -9,9 +9,8 @@ import (
 )
 
 type Logstreamer struct {
-	Logger    *log.Logger
-	buf       *bytes.Buffer
-	readLines string
+	Logger *log.Logger
+	buf    *bytes.Buffer
 	// If prefix == stdout, colors green
 	// If prefix == stderr, colors red
 	// Else, prefix is taken as-is, and prepended to anything
@@ -83,19 +82,10 @@ func (l *Logstreamer) OutputLines() (err error) {
 			return err
 		}
 
-		l.readLines += line
 		l.out(line)
 	}
 
 	return nil
-}
-
-func (l *Logstreamer) ResetReadLines() {
-	l.readLines = ""
-}
-
-func (l *Logstreamer) ReadLines() string {
-	return l.readLines
 }
 
 func (l *Logstreamer) FlushRecord() string {

--- a/logstreamer.go
+++ b/logstreamer.go
@@ -26,6 +26,22 @@ type Logstreamer struct {
 	colorReset string
 }
 
+func NewLogstreamerForWriter(prefix string, writer io.Writer) *Logstreamer {
+	logger := log.New(writer, prefix, 0)
+	return NewLogstreamer(logger, "", false)
+}
+
+func NewLogstreamerForStdout(prefix string) *Logstreamer {
+	// logger := log.New(os.Stdout, prefix, log.Ldate|log.Ltime)
+	logger := log.New(os.Stdout, prefix, 0)
+	return NewLogstreamer(logger, "", false)
+}
+
+func NewLogstreamerForStderr(prefix string) *Logstreamer {
+	logger := log.New(os.Stderr, prefix, 0)
+	return NewLogstreamer(logger, "", false)
+}
+
 func NewLogstreamer(logger *log.Logger, prefix string, record bool) *Logstreamer {
 	streamer := &Logstreamer{
 		Logger:     logger,


### PR DESCRIPTION
# Cleanup
- removed `readLines` as it was not used at all
- replaced `(err error)` with `error` where the `err` var was not used
- removed `out()` functions `error` return, as it does not return an error in any case
# Utility constructor functions

`NewLogstreamerForWriter`, `NewLogstreamerForStdout` and `NewLogstreamerForStderr` was added, partly as an example for other and because (at least in our case) these turned out quite handy
# Issue fix in `OutputLines()`

This is the most significant change. Switched the order of printing the `line` to `out` and the error checking. As noted in the Go docs (https://golang.org/pkg/bytes/#Buffer.ReadString) the `ReadString` method might return with some content even if it returns an `error`. This is most significant in case the error is actually `io.EOF`, which happens if the last line of the buffer does not contain a newline character. This can easily be reproduced by:

```
#!/bin/bash
printf 'no newline' > testfile.txt
cat testfile.txt
```

Previously if we tried to stream the output / log of this script the result of `cat` was simply skipped by `OutputLines`.
