### PR TITLE
Bug in Flush() fixed

### DIFF
--- a/logstreamer.go
+++ b/logstreamer.go
@@ -81,7 +81,7 @@ func (l *Logstreamer) Close() error {
 }
 
 func (l *Logstreamer) Flush() error {
-	var p []byte
+	p := make([]byte, l.buf.Len())
 	if _, err := l.buf.Read(p); err != nil {
 		return err
 	}

--- a/logstreamer_test.go
+++ b/logstreamer_test.go
@@ -1,10 +1,13 @@
 package logstreamer
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -83,5 +86,26 @@ func TestLogstreamerErr(t *testing.T) {
 		fmt.Printf("Good. command finished with %s. %s. \n", err.Error(), logStreamerErr.FlushRecord())
 	} else {
 		t.Fatal("This command should have failed")
+	}
+}
+
+func TestLogstreamerFlush(t *testing.T) {
+	const text = "Text without newline"
+
+	var buffer bytes.Buffer
+	byteWriter := bufio.NewWriter(&buffer)
+
+	logger := log.New(byteWriter, "", 0)
+	logStreamerOut := NewLogstreamer(logger, "", false)
+	defer logStreamerOut.Close()
+
+	logStreamerOut.Write([]byte(text))
+	logStreamerOut.Flush()
+	byteWriter.Flush()
+
+	s := strings.TrimSpace(string(buffer.Bytes()))
+
+	if s != text {
+		t.Fatalf("Expected '%s', got '%s'.", text, s)
 	}
 }


### PR DESCRIPTION
If the last entry sent to the log streamer does not end with a newline character, it will not be written out at all. The reason is that in the `Flush()` method the buffer `p` passed to `buf.Read(p)` is of length 0. Therefore no bytes are copied into the buffer and the entry is not logged at all.

I provided a test case showing the bug in logstreamer_test.go.

Best Regards,
Thomas

